### PR TITLE
Fix: Ensure Leaflet map displays and align client menu panel

### DIFF
--- a/app.js
+++ b/app.js
@@ -326,7 +326,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function collectDynamicValues(containerId, itemSelector, isGrouped, fieldsMap = null) {
     const container = document.getElementById(containerId);
     if (!container) return [];
-    
+
     const items = container.querySelectorAll(isGrouped ? `.${itemSelector}` : itemSelector); // If not grouped, itemSelector is the field class itself
     const allEntriesData = [];
 
@@ -342,7 +342,7 @@ document.addEventListener('DOMContentLoaded', () => {
               entryData[keyInMap] = field.value.trim();
               hasValue = true;
             } else {
-              entryData[keyInMap] = ''; 
+              entryData[keyInMap] = '';
             }
           }
         }
@@ -385,13 +385,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (clientOrderForm) {
       clientOrderForm.addEventListener('submit', (event) => {
-        event.preventDefault(); 
+        event.preventDefault();
         let isValid = true;
 
         // --- Validate Static Fields ---
         const pickupNameEl = document.getElementById('pickup-name');
         if (!validateField(pickupNameEl, Validators.isNotEmpty, 'Pick-up name is required.')) isValid = false;
-        
+
         const clientRefEl = document.getElementById('client-ref-number');
         if (!validateField(clientRefEl, value => Validators.isNotEmpty(value) && Validators.matchesPattern(value, /^[A-Za-z0-9\-]+$/), 'Client reference must be alphanumeric/dashes and not empty.')) isValid = false;
 
@@ -399,7 +399,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Example: Validate first pickup address is not empty
         const firstPickupAddressEl = document.querySelector('#pickup-addresses-container .pickup-address');
         if (firstPickupAddressEl && !validateField(firstPickupAddressEl, Validators.isNotEmpty, 'At least one pick-up address is required.')) isValid = false;
-        
+
         // Example: Validate all provided pickup contacts for pattern (if any)
         const pickupContactFields = document.querySelectorAll('#pickup-contacts-container .pickup-contact');
         pickupContactFields.forEach(contactField => {
@@ -407,7 +407,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if(!validateField(contactField, Validators.isPhoneNumber, 'Invalid phone number format.')) isValid = false;
           }
         });
-        
+
         // Example: Validate item quantity if an item description is filled
         const itemEntries = document.querySelectorAll('#item-descriptions-container .item-description-entry');
         itemEntries.forEach((entry, index) => {
@@ -459,7 +459,7 @@ document.addEventListener('DOMContentLoaded', () => {
         resetDynamicSection('pickup-contacts-container', 'pickup-contact-entry', { firstEntryFieldSelector: '.pickup-contact', placeholderPrefix: 'Pick-up Contact' });
         resetDynamicSection('delivery-contacts-container', 'delivery-contact-entry', { firstEntryFieldSelector: '.delivery-contact', placeholderPrefix: 'Delivery Contact' });
         resetDynamicSection('item-descriptions-container', 'item-description-entry', { firstEntryFieldSelector: '.item-description', placeholderPrefix: 'Item Description' });
-        
+
         // Populate a new order number for the next order
         populateOrderNumber();
       });
@@ -493,7 +493,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!validateField(plateEl, Validators.isNotEmpty, `Plate number for vehicle ${index + 1} is required.`)) isValid = false;
           }
         });
-        
+
         // Example: Validate driver contacts for pattern (if any)
         const driverContactFields = document.querySelectorAll('#driver-contacts-container .driver-contact');
         driverContactFields.forEach(contactField => {
@@ -506,7 +506,7 @@ document.addEventListener('DOMContentLoaded', () => {
           alert('Please correct the errors in the form.');
           return;
         }
-        
+
         const driverName = driverNameEl.value; // Use validated element's value
 
         const vehicles = collectDynamicValues('driver-vehicles-container', 'vehicle-entry', true, {

--- a/index.html
+++ b/index.html
@@ -561,7 +561,7 @@
 
     <div id="main-content-area">
       <section
-        id="map-container" 
+        id="map-container"
         aria-label="Delivery and Driver Map"
         role="region"
       >

--- a/style.css
+++ b/style.css
@@ -79,9 +79,8 @@ body {
   display: flex; /* To make map-placeholder take full height */
 }
 #map-placeholder {
-  flex-grow: 1; /* Takes full space of map-container */
-  height: auto; /* Override fixed height, let it fill flex container */
-  min-height: 500px; /* Ensure a minimum height */
+  flex-grow: 1; /* Takes full space of map-container if parent is column flex, or full width if row flex */
+  height: 500px; /* Explicit height for Leaflet initialization */
   width: 100%;
   box-sizing: border-box;
   outline: none; /* Remove focus outline, but accessible focus managed in JS */
@@ -115,13 +114,15 @@ body {
 }
 
 #client-menu-container {
-  left: 20px; /* Default position for client menu */
+  left: 10px; /* Consistent 10px from left edge */
+  right: auto; /* Ensure no conflict if a 'right' was ever set */
   width: 360px; /* Default width for larger screens */
   background-color: #e6f7ff; /* light blue for client */
 }
 
 #driver-menu-container {
-  right: 20px; /* Default position for driver menu */
+  right: 10px; /* Consistent 10px from right edge */
+  left: auto; /* Ensure no conflict if a 'left' was ever set */
   width: 360px; /* Default width for larger screens */
   background-color: #e6ffe6; /* light green for driver */
 }

--- a/tests.js
+++ b/tests.js
@@ -19,7 +19,7 @@ function logTestResult(testName, passed, message = '') {
 let currentTestDOMContainer = null;
 
 function setupDOM(html) {
-  cleanupDOM(); 
+  cleanupDOM();
   const container = document.createElement('div');
   container.id = 'test-container-' + Date.now() + Math.random().toString(36).substring(2, 7);
   container.innerHTML = html;
@@ -112,7 +112,7 @@ function testErrorAlerts() {
       tempMapPlaceholder.id = 'map-placeholder';
       document.body.appendChild(tempMapPlaceholder);
   }
-  
+
   initMap(); // Call the function that should error
 
   const mapInitErrorMsg = "Error: Error initializing Leaflet map: L is not defined"; // Or similar, depends on exact error
@@ -125,7 +125,7 @@ function testErrorAlerts() {
       testPassed = false;
       messages.push(`Map placeholder error HTML not set correctly. Got: ${mapPlaceholder.innerHTML}`);
   }
-  
+
   window.L = originalL; // Restore
   if(tempMapPlaceholder) tempMapPlaceholder.remove();
   restoreAlert(); // Restore alert for next sub-test
@@ -146,7 +146,7 @@ function testErrorAlerts() {
   if (originalOrderNumberField) originalOrderNumberField.id = 'order-number'; // Restore
   restoreAlert();
   logTestResult(`${testSuiteName} - populateOrderNumber Error`, testPassed, messages.join('; '));
-  
+
   cleanupDOM();
 }
 
@@ -171,7 +171,7 @@ function testInputValidation() {
   let pickupNameInput = clientForm.querySelector('#pickup-name');
   let clientRefInput = clientForm.querySelector('#client-ref-number');
   let firstPickupAddressInput = clientForm.querySelector('.pickup-address');
-  
+
   mockAlert();
   mockConsoleLog(); // To check if "New Order" is logged
 
@@ -179,7 +179,7 @@ function testInputValidation() {
   clientRefInput.value = 'VALID-REF'; // Set one field valid to isolate test
   firstPickupAddressInput.value = 'Valid Address';
   // Pickup name is left empty
-  
+
   // Directly call the handler logic (simplified for test focus)
   // In a real scenario, you might need to trigger the event if handler is not exposed
   // For now, we assume handleCreateOrder is accessible or we test its validation part
@@ -218,7 +218,7 @@ function testInputValidation() {
 
   mockAlert();
   mockConsoleLog();
-  
+
   pickupNameInput.value = 'Valid Name';
   firstPickupAddressInput.value = 'Valid Address';
   clientRefInput.value = 'INVALID CHARS!!'; // Invalid pattern
@@ -246,7 +246,7 @@ function testInputValidation() {
   pickupNameInput = clientForm.querySelector('#pickup-name');
   clientRefInput = clientForm.querySelector('#client-ref-number');
   firstPickupAddressInput = clientForm.querySelector('.pickup-address');
-  
+
   mockAlert();
   mockConsoleLog();
 
@@ -291,7 +291,7 @@ function testInputValidation() {
       <div><label for="driver-name-static">Driver Name:</label><input type="text" id="driver-name-static"/></div>
       <button type="submit" id="update-profile-btn">Update Profile</button>
     </form>`;
-  
+
   // Test 4: Driver form - required field empty
   let driverFormContainer = setupDOM(driverFormHTML);
   let driverForm = driverFormContainer.querySelector('#driver-profile-form');
@@ -303,7 +303,7 @@ function testInputValidation() {
   // driverNameInput is left empty
   let isValidDriver = true;
   if (!window.validateField(driverNameInput, window.Validators.isNotEmpty, 'Driver name is required.')) isValidDriver = false;
-  
+
   if (!isValidDriver) {
     window.alert('Please correct the errors in the form.');
   } else {
@@ -333,14 +333,14 @@ function runTests() {
   originalConsoleLog.log('Starting tests...'); // Use original for this top-level log
 
   let functionsAvailable = true;
-  if (typeof window.setupDynamicFieldSectionListeners !== 'function' || 
+  if (typeof window.setupDynamicFieldSectionListeners !== 'function' ||
       typeof window.handleDynamicFieldRemove !== 'function' ||
       typeof window.validateField !== 'function' ||
       typeof window.Validators !== 'object') {
     functionsAvailable = false;
     logTestResult('Global Setup Check', false, 'Required functions (setupDynamicFieldSectionListeners, handleDynamicFieldRemove, validateField, Validators) not exposed by app.js.');
   }
-  
+
   if (typeof initMenuToggles !== 'function') {
     functionsAvailable = false;
     logTestResult('Global Setup Check for Menus', false, 'initMenuToggles not global.');
@@ -374,7 +374,7 @@ document.addEventListener('DOMContentLoaded', () => {
     button.textContent = 'Run Tests (Dynamically Added)';
     if(document.body) {
         document.body.insertBefore(button, document.body.firstChild);
-    } else { 
+    } else {
         document.documentElement.appendChild(button);
     }
     button.addEventListener('click', runTests);


### PR DESCRIPTION
This commit addresses two main issues:
1.  **Leaflet Map Not Displaying:**
    - The map container (`#map-placeholder`) was potentially not having a computable height at the time of Leaflet's initialization, which is a common cause for the map not rendering.
    - Fixed by setting an explicit `height: 500px;` in `style.css` for `#map-placeholder`. This provides a defined area for Leaflet to render into. The `flex-grow: 1;` property will still allow it to expand if the parent container grows larger.

2.  **Client Order Menu Panel Positioning:**
    - Adjusted the CSS for `#client-menu-container` to position it in the top-left corner. It now uses `left: 10px;` and `right: auto;`.
    - Symmetrically, `#driver-menu-container` was also adjusted to use `right: 10px;` (it was previously `20px` on desktop) for consistent 10px spacing from the viewport edges for both menus, matching existing mobile styles.
    - This ensures the client menu is anchored to the left and the driver menu to the right, as intended.