### PR TITLE
Fix: Resolve map display via CSP and correct tests.js error

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
     content="
       default-src 'self';
       script-src 'self' https://unpkg.com 'nonce-abc123';
-      style-src 'self' https://unpkg.com 'nonce-abc123';
-      img-src 'self' data:;
+      style-src 'self' https://unpkg.com 'nonce-abc123' 'unsafe-inline';
+      img-src 'self' data: https://*.tile.openstreetmap.org;
       connect-src 'self';
       font-src 'self';
       object-src 'none';

--- a/tests.js
+++ b/tests.js
@@ -330,7 +330,7 @@ function testInputValidation() {
 // --- Run All Tests ---
 function runTests() {
   resetTestState();
-  originalConsoleLog.log('Starting tests...'); // Use original for this top-level log
+  originalConsoleLog('Starting tests...'); // Use original for this top-level log
 
   let functionsAvailable = true;
   if (typeof window.setupDynamicFieldSectionListeners !== 'function' ||
@@ -355,7 +355,7 @@ function runTests() {
     logTestResult('Core Tests Skipped', false, 'Due to missing global functions, core application tests were skipped.');
   }
 
-  originalConsoleLog.log(`\nTests finished. ${passCount}/${testCount} passed.`);
+  originalConsoleLog(`\nTests finished. ${passCount}/${testCount} passed.`);
   if (allTestMessages.length > 0) {
     originalConsoleError("Detailed failures:\n" + allTestMessages.join('\n'));
   }


### PR DESCRIPTION
This commit addresses two critical issues:
1.  **Leaflet Map Not Displaying due to Content Security Policy:**
    - I modified the CSP in `index.html`: - Added `'unsafe-inline'` to the `style-src` directive. This is necessary as Leaflet dynamically applies inline styles to its map elements. - Added `https://*.tile.openstreetmap.org` to the `img-src` directive to allow map tiles to be loaded from OpenStreetMap servers.
    - These changes should resolve the errors where the browser was blocking Leaflet's essential operations, allowing the map to render correctly.

2.  **TypeError in `tests.js`:**
    - I corrected an error in `tests.js` where the stored original `console.log` function was being called incorrectly as `originalConsoleLog.log(...)` instead of directly as `originalConsoleLog(...)`.
    - This fixes the `TypeError: originalConsoleLog.log is not a function` and allows the test suite's own console messages to be logged correctly.