### PR TITLE
Feat: Enhance modal UX and refine column visuals

### DIFF
--- a/app.js
+++ b/app.js
@@ -614,58 +614,68 @@ function initMenuToggles() {
     return;
   }
 
-  clientMenuToggleBtn.addEventListener('click', () => {
-    const isClientMenuVisible = clientMenuPanel.style.display === 'block';
-    
-    // Toggle client menu
-    clientMenuPanel.style.display = isClientMenuVisible ? 'none' : 'block';
-    clientMenuPanel.hidden = isClientMenuVisible;
-    clientMenuToggleBtn.setAttribute('aria-expanded', !isClientMenuVisible);
-    
-    // If opening client menu, ensure driver menu is closed
-    if (!isClientMenuVisible) { // i.e., if client menu was hidden and is now being shown
-      driverMenuPanel.style.display = 'none';
-      driverMenuPanel.hidden = true;
-      driverMenuToggleBtn.setAttribute('aria-expanded', 'false');
-    }
-  });
-
-  driverMenuToggleBtn.addEventListener('click', () => {
-    const isDriverMenuVisible = driverMenuPanel.style.display === 'block';
-    
-    // Toggle driver menu
-    driverMenuPanel.style.display = isDriverMenuVisible ? 'none' : 'block';
-    driverMenuPanel.hidden = isDriverMenuVisible;
-    driverMenuToggleBtn.setAttribute('aria-expanded', !isDriverMenuVisible);
-    
-    // If opening driver menu, ensure client menu is closed
-    if (!isDriverMenuVisible) { // i.e., if driver menu was hidden and is now being shown
-      clientMenuPanel.style.display = 'none';
-      clientMenuPanel.hidden = true;
-      clientMenuToggleBtn.setAttribute('aria-expanded', 'false');
-    }
-  });
-
-  // Optional: Close menus if user clicks outside of them on the map or app container
-  // This is more advanced and might be added later if needed.
-  // For example, document.getElementById('app-container').addEventListener('click', (e) => { ... });
-
-  // Event listeners for the new close buttons
-  closeClientMenuBtn.addEventListener('click', () => {
+  function hideClientMenu() {
     if (clientMenuPanel) {
       clientMenuPanel.style.display = 'none';
       clientMenuPanel.hidden = true;
       clientMenuToggleBtn.setAttribute('aria-expanded', 'false');
     }
-  });
+  }
 
-  closeDriverMenuBtn.addEventListener('click', () => {
+  function hideDriverMenu() {
     if (driverMenuPanel) {
       driverMenuPanel.style.display = 'none';
       driverMenuPanel.hidden = true;
       driverMenuToggleBtn.setAttribute('aria-expanded', 'false');
     }
+  }
+
+  clientMenuToggleBtn.addEventListener('click', () => {
+    const isClientMenuVisible = clientMenuPanel.style.display === 'block';
+    
+    if (isClientMenuVisible) {
+      hideClientMenu();
+    } else {
+      clientMenuPanel.style.display = 'block'; // Or 'flex' if CSS uses that for the overlay
+      clientMenuPanel.hidden = false;
+      clientMenuToggleBtn.setAttribute('aria-expanded', 'true');
+      hideDriverMenu(); // Ensure other menu is closed
+    }
   });
+
+  driverMenuToggleBtn.addEventListener('click', () => {
+    const isDriverMenuVisible = driverMenuPanel.style.display === 'block';
+
+    if (isDriverMenuVisible) {
+      hideDriverMenu();
+    } else {
+      driverMenuPanel.style.display = 'block'; // Or 'flex'
+      driverMenuPanel.hidden = false;
+      driverMenuToggleBtn.setAttribute('aria-expanded', 'true');
+      hideClientMenu(); // Ensure other menu is closed
+    }
+  });
+
+  // Event listeners for close buttons
+  closeClientMenuBtn.addEventListener('click', hideClientMenu);
+  closeDriverMenuBtn.addEventListener('click', hideDriverMenu);
+
+  // Add close on overlay click
+  if (clientMenuPanel) {
+    clientMenuPanel.addEventListener('click', function(event) {
+      if (event.target === clientMenuPanel) {
+        hideClientMenu();
+      }
+    });
+  }
+
+  if (driverMenuPanel) {
+    driverMenuPanel.addEventListener('click', function(event) {
+      if (event.target === driverMenuPanel) {
+        hideDriverMenu();
+      }
+    });
+  }
 }
 
 

--- a/style.css
+++ b/style.css
@@ -1,3 +1,7 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 /* Basic Styles */
 body {
   font-family: Arial, sans-serif;
@@ -8,6 +12,7 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  font-size: 14px; /* UPDATED base font size */
 }
 
 /* Typography */
@@ -142,6 +147,7 @@ h1, h2, h3, h4, h5, legend {
   max-height: 90vh; /* Fit on screen */
   overflow-y: auto; /* Scrollable content */
   position: relative; /* For absolute positioning of the close button inside */
+  opacity: 0.7; /* NEW: Set opacity */
 }
 
 
@@ -187,6 +193,8 @@ h1, h2, h3, h4, h5, legend {
 .form-column {
   /* Default: full width when stacked */
   width: 100%;
+  padding: 5px; /* 5px inset for content within the column */
+  /* box-sizing: border-box; /* Ensured by global rule */
 }
 .form-column + .form-column { /* Add space above subsequent columns when stacked */
   margin-top: 20px;
@@ -257,10 +265,16 @@ h1, h2, h3, h4, h5, legend {
   .form-column {
     flex: 1;
     min-width: 0; /* Flex item fix */
+    /* padding: 5px; /* Already applied in base .form-column style */
     /* margin-top is reset for side-by-side columns */
   }
   .form-column + .form-column {
     margin-top: 0;
+  }
+  .form-section-columns .form-column:first-child {
+    border-right: 1px solid #ced4da; /* Palette: Borders - Vertical divider */
+    /* The 'gap' on .form-section-columns provides space around this border.
+       The 5px padding on .form-column is inside this border. */
   }
 
 


### PR DESCRIPTION
This commit introduces several UI/UX improvements to the modal dialogs and their internal form column layouts.

Key changes:

1.  **Modal Behavior:**
    *   Implemented "close on outside click" functionality in `app.js`.
        Clicking on the semi-transparent overlay of the modal
        (`#client-menu-container` or `#driver-menu-container`) now closes
        the active modal.
    *   Refactored menu show/hide logic in `initMenuToggles` into helper
        functions for better code organization.

2.  **Modal Visuals (CSS - `style.css`):**
    *   Set `opacity: 0.7;` for the `.menu-modal-content` class, making the
        modal content box semi-transparent.
    *   Adjusted the base `font-size` for the `body` element to `14px`.

3.  **Form Column Refinements (CSS - `style.css`):**
    *   Added a global `box-sizing: border-box;` rule for more
        predictable layouts with padding and borders.
    *   On wider screens (`min-width: 769px`), a vertical divider
        (`border-right: 1px solid #ced4da;`) is now added to the first
        `.form-column` within a `.form-section-columns` layout.
    *   Applied `padding: 5px;` to `.form-column` elements to create a
        slight "inset" effect for their content, distinguishing it from
        the main modal padding and the inter-column gap.

These changes improve the usability of the modals and provide a more refined visual structure for the two-column form layouts.