### PR TITLE
Fix alert on map failure

### DIFF
--- a/app.js
+++ b/app.js
@@ -749,7 +749,9 @@ function initMap() {
       
     console.log('Map initialized successfully.');
   } catch (error) {
-    console.error('Error: Error initializing Leaflet map: ' + error.message);
+    const msg = 'Error initializing Leaflet map: ' + error.message;
+    console.error('Error: ' + msg);
+    alert(msg);
     mapPlaceholder.innerHTML = '<p style="color:red; text-align:center; font-weight:bold;">Map Error: Could not initialize the map. ' + error.message + '</p>';
   }
 }


### PR DESCRIPTION
## Summary
- alert the user when Leaflet map fails to initialize

## Testing
- `node tests.js` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6842aca84d90832bb80dcb2ec455550c