### PR TITLE
Add Delays card and center performance layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,13 @@
           </div>
           <!-- Optional icon placeholder: <img class="stat-card-icon" src="path/to/icon.svg" alt="Delivery Icon"> -->
         </div>
+
+        <div class="stat-card" id="delays-card">
+          <div class="stat-card-title">Delays</div>
+          <div class="stat-card-percentages">
+            <span class="percentage-item">Delays: 5%</span> <!-- Placeholder -->
+          </div>
+        </div>
       </div>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -1080,26 +1080,28 @@ legend.collapsible-trigger.active .collapsible-icon {
 /* Performance Display Area (Below Header) */
 #performance-display-area {
   display: flex;
+  flex-direction: column;
+  align-items: center;
   padding: 20px 15px;
-  align-items: flex-start;
+  gap: 20px;
   /* background-color: #f0f0f0; /* Optional: for visual debugging */
 }
 
 #performance-today-label {
-  flex-shrink: 0;
-  margin-right: 25px;
+  margin: 0;
   font-weight: bold;
   font-size: 1.2em;
   color: #333;
+  text-align: center;
   /* padding-top: 10px; /* Adjust if needed for card alignment */
 }
 
 #stat-cards-container {
-  flex-grow: 1;
   display: flex;
   justify-content: center;
   gap: 20px;
   flex-wrap: wrap;
+  width: 100%;
 }
 
 /* Stat Card Styling */


### PR DESCRIPTION
## Summary
- center `Performance Today` label and stat cards
- add a Delays card for performance stats

## Testing
- `node tests.js` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68456e98e534832bb2a67d1a9d1fd69c