### PR TITLE
Improve modals and add server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Logistics Map App
+
+This project demonstrates draggable client and driver forms with a Leaflet map. A small Node.js server generates a unique CSP nonce for each request and serves the static files.
+
+## Requirements
+
+- Node.js 18+
+
+## Setup
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm start
+```
+
+Open <http://localhost:3000> in your browser.
+
+## Security
+
+The server generates a cryptographically strong nonce for each response and injects it into the HTML, providing a strict Content Security Policy. User data is handled entirely on the client; in production consider adding server-side validation and storage.
+

--- a/app.js
+++ b/app.js
@@ -750,10 +750,7 @@ function onDragStart(event) {
   activeModal = header.closest('.menu-modal-content');
   if (!activeModal) return;
 
-  if (window.innerWidth < 768) { // Check screen width *before* preventDefault and listener attachment
-    // For small screens, don't initiate drag.
-    return;
-  }
+  // Allow dragging on all screen sizes
 
   event.preventDefault(); // Prevent text selection, etc., *only if dragging*
 

--- a/index.html
+++ b/index.html
@@ -2,21 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <!-- IMPORTANT: The CSP nonce 'abc123' is for development purposes only. In a production environment, a unique, cryptographically strong nonce should be generated and supplied by the server for each request to ensure proper Content Security Policy protection. -->
-  <meta http-equiv="Content-Security-Policy"
-    content="
-      default-src 'self';
-      script-src 'self' https://unpkg.com 'nonce-abc123';
-      style-src 'self' https://unpkg.com 'nonce-abc123' 'unsafe-inline';
-      img-src 'self' data: https://*.tile.openstreetmap.org;
-      connect-src 'self';
-      font-src 'self';
-      object-src 'none';
-      base-uri 'self';
-      form-action 'self';
-      frame-ancestors 'none';
-    "
-  />
+  <!-- The nonce value "abc123" will be dynamically replaced by server.js. -->
+  <!-- Content Security Policy is provided via an HTTP header. -->
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>OPS Logistics Map App</title>
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ntp0-app",
+  "version": "1.0.0",
+  "description": "Sample app with dynamic CSP nonce and static files",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+// Serve static files from the repository root
+app.use(express.static(__dirname));
+
+app.get('/', (req, res) => {
+  const nonce = crypto.randomBytes(16).toString('base64');
+  const htmlPath = path.join(__dirname, 'index.html');
+  fs.readFile(htmlPath, 'utf8', (err, data) => {
+    if (err) return res.status(500).send('Error loading page');
+    const page = data.replace(/abc123/g, nonce);
+    res.setHeader('Content-Security-Policy', `default-src 'self'; script-src 'self' https://unpkg.com 'nonce-${nonce}'; style-src 'self' https://unpkg.com 'nonce-${nonce}' 'unsafe-inline'; img-src 'self' data: https://*.tile.openstreetmap.org; connect-src 'self'; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';`);
+    res.send(page);
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/style.css
+++ b/style.css
@@ -150,7 +150,8 @@ h1, h2, h3, h4, h5, legend {
   /* justify-content: center; /* Removed */
   z-index: 1001; /* This z-index is for the container itself, modal content will be higher */
   /* Visibility is controlled by 'hidden' attribute and direct style.display in JS */
-  pointer-events: none; /* Allow clicks to pass through the container if it's covering the screen but invisible */
+  /* Allow overlay to capture clicks so modals can be closed by clicking outside */
+  pointer-events: auto;
 }
 
 /* menu-modal-content will be visible/interactive based on its parent's display style */


### PR DESCRIPTION
## Summary
- implement a small Express server that injects a dynamic CSP nonce
- update index.html to rely on the server supplied CSP
- allow closing modals by clicking the overlay
- permit dragging on small screens
- document setup in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_684577583d1c832bab47f6342ad1ce87