### PR TITLE
Improve README with nonce and setup details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Logistics Map App
 
-This project demonstrates draggable client and driver forms with a Leaflet map. A small Node.js server generates a unique CSP nonce for each request and serves the static files.
+This project demonstrates draggable client and driver forms with a Leaflet map. A small Node.js server generates a unique nonce for each request, injects it into the page's `Content-Security-Policy` header, and serves the static files.
 
 ## Requirements
 
@@ -8,10 +8,13 @@ This project demonstrates draggable client and driver forms with a Leaflet map. 
 
 ## Setup
 
-Install dependencies and start the development server:
+Install dependencies and start the development server in the repository root:
 
 ```bash
+# install dependencies
 npm install
+
+# start the server once packages are installed
 npm start
 ```
 
@@ -19,5 +22,5 @@ Open <http://localhost:3000> in your browser.
 
 ## Security
 
-The server generates a cryptographically strong nonce for each response and injects it into the HTML, providing a strict Content Security Policy. User data is handled entirely on the client; in production consider adding server-side validation and storage.
+The server generates a cryptographically strong nonce for each response. `server.js` uses `crypto.randomBytes` to create a 16‑byte value, inserts the nonce into the HTML, and sets a `Content-Security-Policy` header referencing it. User data is handled entirely on the client; in production consider adding server-side validation and storage.
 


### PR DESCRIPTION
## Summary
- clarify nonce injection into the Content-Security-Policy header
- provide explicit setup steps for `npm install` then `npm start`

## Testing
- `npm install`
- `npm start` (terminated after launch)

------
https://chatgpt.com/codex/tasks/task_e_6845d9f7e14c832b9d2fcf8a2deb10f4